### PR TITLE
Added with_base64_encoded for complex strings like json to prevent parsing errors.

### DIFF
--- a/src/Common.js
+++ b/src/Common.js
@@ -68,12 +68,18 @@ function actionConfigRead( actionDir )
 
 //
 
-function actionOptionsParse( src )
+function actionOptionsParse( src, base64Encoded )
 {
   const result = Object.create( null );
   for( let i = 0 ; i < src.length ; i++ )
   {
     const splits = _.strStructureParse({ src : src[ i ], toNumberMaybe : 0 });
+    if(base64Encoded) {
+      for (const [key, value] of Object.entries(splits)) {
+        let buff = new Buffer.from(value, 'base64').toString('ascii');
+          splits[key] = buff;
+      }
+    }
     _.map.extend( result, splits );
   }
   return result;

--- a/src/Retry.js
+++ b/src/Retry.js
@@ -55,7 +55,10 @@ function retry( scriptType )
         return null;
 
         const optionsStrings = core.getMultilineInput( 'with' );
+        const optionsStringsBase64Encoded = core.getMultilineInput( 'with_base4_encoded' );
         const options = common.actionOptionsParse( optionsStrings );
+        const optionsBase64Encoded  = common.actionOptionsParse( optionsStringsBase64Encoded, true );
+        _.map.extend( options, optionsBase64Encoded );
         _.map.sureHasOnly( options, config.inputs );
 
         if( _.strBegins( config.runs.using, 'node' ) )


### PR DESCRIPTION
Added with_base64_encoded for complex strings like json to prevent parsing errors.