### PR TITLE
READY : Improve js action, change runner

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
     required: false
     default: 0
 runs:
-  using: 'node12'
+  using: 'node16'
   pre: 'src/Pre.js'
   main: 'src/Main.js'
   post: 'src/Post.js'


### PR DESCRIPTION
Update for the action. It should fix the GitHub warning about runner. 
See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ 