### PR TITLE
Use $GITHUB_OUTPUT instead of depecrated set-output

### DIFF
--- a/.github/workflows/JsActionPublish.yml
+++ b/.github/workflows/JsActionPublish.yml
@@ -47,7 +47,7 @@ jobs :
     - name : Save npm version
       id : getnpmver
       run : |
-        echo "::set-output name=npmver::$(npm -v)"
+        echo "npmver=$(npm -v)" >> $GITHUB_OUTPUT
     - name : Update npm if current version is 6
       if : "startsWith( steps.getnpmver.outputs.npmver, '6.' )"
       run : npm install -g npm@latest-6

--- a/.github/workflows/JsActionPush.yml
+++ b/.github/workflows/JsActionPush.yml
@@ -48,7 +48,7 @@ jobs :
     - name : Save npm version
       id : getnpmver
       run : |
-        echo "::set-output name=npmver::$(npm -v)"
+        echo "npmver=$(npm -v)" >> $GITHUB_OUTPUT
     - name : Update npm if current version is 6
       if : "startsWith( steps.getnpmver.outputs.npmver, '6.' )"
       run : npm install -g npm@latest-6


### PR DESCRIPTION
### Description

`set-output` is deprecated and will be removed starting 1st June 2023 ([see](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/))

`$GITHUB_STATE` need to be used instead