### PR TITLE
Fix resolve remote action path in the source repository

### DIFF
--- a/src/Common.js
+++ b/src/Common.js
@@ -43,17 +43,8 @@ function remotePathFromActionName( name )
   }
   else
   {
-    const regex = /^([^\/]+\/[^\/]+)\/?(\S*)(@\S*)/;
-    const actionRepo = name.replace( regex, '$1.git/$3' );
-    const actionDir = name.replace( regex, '$2' );
-    const parseResult = _.git.path.parse( `https://github.com/${_.str.replace( actionRepo, '@', '!' ) }` );
-
-    const remotePath = Object.assign(parseResult, {localVcsPath: parseResult.localVcsPath + actionDir});
-
-    console.log('remotePath: ', remotePath, 'from Action name:', name );
-
-    return remotePath;
-
+    name = name.replace( /^([^\/]+\/[^\/]+)\//, '$1.git/' );
+    return _.git.path.parse( `https://github.com/${ _.str.replace( name, '@', '!' ) }` );
   }
 }
 

--- a/src/Common.js
+++ b/src/Common.js
@@ -43,8 +43,17 @@ function remotePathFromActionName( name )
   }
   else
   {
-    name = name.replace( /^(\S*\/\S*)\//, '$1.git/' );
-    return _.git.path.parse( `https://github.com/${ _.str.replace( name, '@', '!' ) }` );
+    const regex = /^([^\/]+\/[^\/]+)\/?(\S*)(@\S*)/;
+    const actionRepo = name.replace( regex, '$1.git/$3' );
+    const actionDir = name.replace( regex, '$2' );
+    const parseResult = _.git.path.parse( `https://github.com/${_.str.replace( actionRepo, '@', '!' ) }` );
+
+    const remotePath = Object.assign(parseResult, {localVcsPath: parseResult.localVcsPath + actionDir});
+
+    console.log('remotePath: ', remotePath, 'from Action name:', name );
+
+    return remotePath;
+
   }
 }
 
@@ -91,7 +100,7 @@ function actionConfigRead( actionDir )
   if( !_.fileProvider.fileExists( configPath ) )
   configPath = _.path.join( actionDir, 'action.yaml' )
 
-  _.assert( _.fileProvider.fileExists( configPath ), 'Expects action path `action.yml` or `action.yaml`' );
+  _.assert( _.fileProvider.fileExists( configPath ), 'Expects action path `action.yml` or `action.yaml` in the action dir: ' + actionDir );
 
   return _.fileProvider.fileRead
   ({

--- a/test/Common.test.s
+++ b/test/Common.test.s
@@ -200,6 +200,22 @@ function remotePathFromActionName( test )
     repo : 'name'
   };
   test.identical( got, exp );
+
+  test.case = 'with org/.github repo under subdirectory path';
+  var got = common.remotePathFromActionName( 'org/.github/actions/foo/bar/action@v1.2.3' );
+  var exp =
+  {
+    protocol : 'https',
+    longPath : 'github.com/org/.github.git/',
+    tag : 'v1.2.3',
+    localVcsPath : 'actions/foo/bar/action',
+    protocols : [ 'https' ],
+    isFixated : false,
+    service : 'github.com',
+    user : 'org',
+    repo : '.github'
+  };
+  test.identical( got, exp );
 }
 
 //


### PR DESCRIPTION
The PR will add support for retry action to be able to resolve remote action path sub-directory in the source repository, i.e. `org/.github/actions/foo/bar@v1.2.3`

Fixes https://github.com/Wandalen/wretry.action/issues/114