### PR TITLE
Update action to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ inputs:
     required: false
     default: false
 runs:
-  using: 'node16'
+  using: 'node20'
   pre: 'src/Pre.js'
   main: 'src/Main.js'
   post: 'src/Post.js'


### PR DESCRIPTION
per https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

this updates the action to use `node20`