### PR TITLE
Update github-actions-typing to v2

### DIFF
--- a/.github/workflows/check-action-typing.yml
+++ b/.github/workflows/check-action-typing.yml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check Action Typing
-        uses: typesafegithub/github-actions-typing@wip
+        uses: typesafegithub/github-actions-typing@v2

--- a/.github/workflows/check-action-typing.yml
+++ b/.github/workflows/check-action-typing.yml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check Action Typing
-        uses: typesafegithub/github-actions-typing@v1
+        uses: typesafegithub/github-actions-typing@wip


### PR DESCRIPTION
Primarily, it also validates actions in subdirectories.