### PR TITLE
ci: pin github action with full-length commit hash

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
   steps:
     - name: retry
       id: retry
-      uses: Wandalen/wretry.action@v3.8.0_js_action
+      uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
       with:
         action: '${{ inputs.action }}'
         command: '${{ inputs.command }}'

--- a/main/action.yml
+++ b/main/action.yml
@@ -62,7 +62,7 @@ runs:
   steps:
     - name: retry
       id: retry
-      uses: Wandalen/wretry.action/main@v3.8.0_js_action
+      uses: Wandalen/wretry.action/main@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
       with:
         action: '${{ inputs.action }}'
         command: '${{ inputs.command }}'

--- a/post/action.yml
+++ b/post/action.yml
@@ -62,7 +62,7 @@ runs:
   steps:
     - name: retry
       id: retry
-      uses: Wandalen/wretry.action/post@v3.8.0_js_action
+      uses: Wandalen/wretry.action/post@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
       with:
         action: '${{ inputs.action }}'
         command: '${{ inputs.command }}'

--- a/pre/action.yml
+++ b/pre/action.yml
@@ -62,7 +62,7 @@ runs:
   steps:
     - name: retry
       id: retry
-      uses: Wandalen/wretry.action/pre@v3.8.0_js_action
+      uses: Wandalen/wretry.action/pre@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
       with:
         action: '${{ inputs.action }}'
         command: '${{ inputs.command }}'


### PR DESCRIPTION
In order to enable `Require actions to be pinned to a full-length commit SHA` setting, this diff is necessary.

  ## Summary

  - Pin GitHub Actions to full-length commit hashes instead of version tags for improved security
  - Update `actions/checkout` from `v4` to `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1)
  - Update `actions/setup-node` from `v4` to `49933ea5288caeca8642d1e84afbd3f7d6820020` (v4.4.0)
  - Update `typesafegithub/github-actions-typing` from `v2` to `184d97003b1300f6a10e286eb98c191e416ff02b` (v2.2.1)

  ## Why

  Pinning actions to commit SHAs instead of mutable tags prevents supply chain attacks where a malicious actor could push malicious code to an existing tag. This follows GitHub's security hardening recommendations for GitHub Actions.