### PR TITLE
Update to Node 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,7 @@ inputs:
     required: false
     default: ${{ github.token }}
 runs:
-  using: 'node20'
+  using: 'node24'
   pre: 'src/Pre.js'
   main: 'src/Main.js'
   post: 'src/Post.js'


### PR DESCRIPTION
Updates `action.yml` from Node 20 to Node 24.

Node 20 actions are deprecated and will be forced to Node 24 starting June 2nd, 2026.